### PR TITLE
regex-based input name sanitization

### DIFF
--- a/unmicst.xml
+++ b/unmicst.xml
@@ -1,4 +1,4 @@
-<tool id="unmicst" name="UnMicst" version="@VERSION@.0" profile="17.09">
+<tool id="unmicst" name="UnMicst" version="@VERSION@.1" profile="17.09">
     <description>UNet Model for Identifying Cells and Segmenting Tissue</description>
     <macros>
         <import>macros.xml</import>
@@ -10,7 +10,7 @@
     <command detect_errors="exit_code"><![CDATA[
     #import re
     #set $cleaned = re.sub('[^\w\-]', '_', str($image.name))
-    #set $typeCorrected = re.match('^(.*?)(_ome)?_tiff?$', $cleaned)[1] + '.ome.tif'
+    #set $typeCorrected = re.match('^(.*?)(_ome)?_tiff?$', $cleaned)[1] + '.' + str($image.file_ext)
 
     ln -s $image '$typeCorrected';
 

--- a/unmicst.xml
+++ b/unmicst.xml
@@ -8,14 +8,15 @@
     @VERSION_CMD@
 
     <command detect_errors="exit_code"><![CDATA[
-    #set $typeCorrected = str($image.name).replace('.ome.tiff','').replace('.ome.tif','').replace('.tiff','').replace('.tif','')+'.ome.tif'
+    #import re
+    #set $cleaned = re.sub('[^\w\-]', '_', str($image.name))
+    #set $typeCorrected = re.match('^(.*?)(_ome)?_tiff?$', $cleaned)[1] + '.ome.tif'
 
     ln -s $image '$typeCorrected';
 
     @CMD_BEGIN@ '$typeCorrected'
 
     --tool $tool
-
     
     #if $stackoutput
     --stackOutput


### PR DESCRIPTION
I've had a few failures when this tool gets unusual input names; these changes sanitize input names to safer alternatives.

notes:
 - my initial issue was caused by filenames with spaces being treated as multiple arguments [in unmicstWrapper.py](https://github.com/ohsu-comp-bio/UnMicst/blob/cad3414c860ef3690b31113be2001ac7f68cdb49/unmicstWrapper.py#L62), but as it turns out extra `.` characters in the filenames caused errors as well, which this PR also fixes

regex breakdown:

`re.sub('[^\w\-]', '_', str($image.name))`
  - replace any character that is not (`^`) an alphanumeric (`\w`) or dash (`\-`) character with an underscore
  - e.g. `p*&$( -#$)+   __ome.tiff` -> `p_____-_________ome_tiff`

`re.match('^(.*?)(_ome)?_tiff?$', $cleaned)[1] + "ome.tif"`
  - `^` - start of string
  - `(.*?)` - first capture group: any character (`.`) any number of times (`*`) non-greedily (`?`)
  - `(_ome)?` - second capture group: the character sequence `_ome` 0 or 1 times (`?`)
  - `_tiff?` - the character sequence `_tif` and another `f` 0 or 1 times (`?`)
  - `[1]` - from the `re.match()` result, take the first capture group and discard extension variations
  - `+ "ome.tif"` - append correct extension
  - e.g.:
    - `p_____-_________ome_tiff` -> `p_____-________.ome.tif`
    - `abc_tiff` -> `abc.ome.tif`
    - `xyz_tif` -> `xyz.ome.tif`
```